### PR TITLE
feat: change user password and system token

### DIFF
--- a/project/server/auth/views.py
+++ b/project/server/auth/views.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 
 from datetime import datetime
 from flask import Blueprint, request, make_response, jsonify
@@ -263,6 +264,74 @@ class SystemUserAPI(MethodView):
             return make_response(jsonify({'message': str(e)})), 401
 
 
+class UpdateSystemTokenAPI(MethodView):
+    """
+    Rotate a system's API token; requires the current token (same trust model as register/login).
+    """
+    @limiter.limit("100 per day")
+    def patch(self, system_name):
+        try:
+            check_request_body_keys(request.json, ['current_system_token'])
+            data = request.json
+            system = System.query.filter_by(name=system_name).first()
+            if system is None:
+                return make_response(jsonify({'message': 'System not found.'}), 404)
+            if system.token != data['current_system_token']:
+                raise UnauthorizedError('Invalid current system token.')
+
+            new_token = data.get('new_system_token')
+            if new_token is None or new_token == '':
+                new_token = secrets.token_urlsafe(32)
+            elif new_token != system.token:
+                if System.query.filter_by(token=new_token).first() is not None:
+                    raise ConflictError('Token already in use.')
+
+            system.token = new_token
+            db.session.commit()
+
+            return make_response(jsonify({
+                'name': system.name,
+                'token': system.token,
+            }), 200)
+
+        except BadRequestError as e:
+            return make_response(jsonify({'message': str(e)})), 400
+        except UnauthorizedError as e:
+            return make_response(jsonify({'message': str(e)})), 401
+        except ConflictError as e:
+            return make_response(jsonify({'message': str(e)})), 409
+
+
+class UpdateUserPasswordAPI(MethodView):
+    """
+    Change password for the authenticated user; requires current password and a valid access token.
+    """
+    @limiter.limit("1000 per hour")
+    def patch(self):
+        try:
+            auth_token = get_authorization_token(request)
+            user = get_user_from_token(auth_token=auth_token)
+            check_request_body_keys(request.json, ['current_password', 'new_password'])
+            data = request.json
+
+            if not data['new_password']:
+                raise BadRequestError('new_password must not be empty.')
+
+            if not bcrypt.check_password_hash(user.password, data['current_password']):
+                raise UnauthorizedError('Incorrect current password.')
+
+            user.set_password(data['new_password'])
+            user.update_last_activity()
+            db.session.commit()
+
+            return make_response(jsonify({'message': 'Password updated.'}), 200)
+
+        except BadRequestError as e:
+            return make_response(jsonify({'message': str(e)})), 400
+        except UnauthorizedError as e:
+            return make_response(jsonify({'message': str(e)})), 401
+
+
 class LogoutAPI(MethodView):
     """
     Logout Resource
@@ -293,6 +362,8 @@ refresh_view = RefreshTokenAPI.as_view('refresh_api')
 me_view = MeAPI.as_view('user_api')
 system_user_view = SystemUserAPI.as_view('system_user_api')
 logout_view = LogoutAPI.as_view('logout_api')
+update_system_token_view = UpdateSystemTokenAPI.as_view('update_system_token_api')
+update_user_password_view = UpdateUserPasswordAPI.as_view('update_user_password_api')
 
 # add Rules for API Endpoints
 auth_blueprint.add_url_rule(
@@ -329,4 +400,14 @@ auth_blueprint.add_url_rule(
     '/auth/logout',
     view_func=logout_view,
     methods=['POST']
+)
+auth_blueprint.add_url_rule(
+    '/auth/systems/<system_name>/token',
+    view_func=update_system_token_view,
+    methods=['PATCH']
+)
+auth_blueprint.add_url_rule(
+    '/auth/me/password',
+    view_func=update_user_password_view,
+    methods=['PATCH']
 )

--- a/project/server/docs/static/api.yaml
+++ b/project/server/docs/static/api.yaml
@@ -18,9 +18,14 @@ paths:
     post:
   /auth/me:
     get:
+  /auth/me/password:
+    patch:
+      summary: Change password (Bearer access token + current and new password)
   /auth/logout:
     post:
-
+  /auth/systems/{system_name}/token:
+    patch:
+      summary: Rotate system token (requires current_system_token in body)
 
   /auth/login:
     get:

--- a/project/server/models.py
+++ b/project/server/models.py
@@ -57,6 +57,11 @@ class User(db.Model):
     def update_last_activity(self):
         self.last_activity_at = datetime.datetime.now()
 
+    def set_password(self, plain_password):
+        self.password = bcrypt.generate_password_hash(
+            plain_password, app.config.get('BCRYPT_LOG_ROUNDS')
+        ).decode()
+
     def prepare_jwt(self, token_type="access"):
         exp_secs = os.environ['JWT_EXP_DELTA_SECS'] if token_type == 'access' else os.environ['JWT_REFRESH_DELTA_SECS']
 

--- a/project/tests/test_auth.py
+++ b/project/tests/test_auth.py
@@ -76,6 +76,23 @@ class TestAuthBlueprint(BaseTestCase):
             content_type='application/json',
         )
 
+    def patch_system_token(self, system_name, **kwargs):
+        return self.client.patch(
+            '/auth/systems/{}/token'.format(system_name),
+            data=json.dumps(kwargs),
+            content_type='application/json',
+        )
+
+    def patch_user_password(self, access_token, **kwargs):
+        return self.client.patch(
+            '/auth/me/password',
+            data=json.dumps(kwargs),
+            headers={
+                'Authorization': 'Bearer {}'.format(access_token)
+            },
+            content_type='application/json',
+        )
+
     def blacklist_token(self, token):
         blacklist_token = BlacklistToken(token=token)
         db.session.add(blacklist_token)
@@ -549,6 +566,181 @@ class TestAuthBlueprint(BaseTestCase):
             self.assertEqual(response.content_type, 'application/json')
             data = json.loads(response.data.decode())
             self.assertIn('message', data)
+
+    def test_patch_system_token_success_explicit_new(self):
+        """Rotate system token when current token and new token are provided."""
+        with self.client:
+            self.create_system(name=self.DEFAULT_SYSTEM_NAME)
+            old_token = self.get_system_token()
+            reg = self.register_default_user()
+            self.assertEqual(reg.status_code, 201)
+
+            new_token = 'explicit-new-token-value-unique-12345'
+            response = self.patch_system_token(
+                self.DEFAULT_SYSTEM_NAME,
+                current_system_token=old_token,
+                new_system_token=new_token,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = json.loads(response.data.decode())
+            self.assertEqual(data['name'], self.DEFAULT_SYSTEM_NAME)
+            self.assertEqual(data['token'], new_token)
+
+            system = System.query.filter_by(name=self.DEFAULT_SYSTEM_NAME).first()
+            self.assertEqual(system.token, new_token)
+
+            login_old = self.login_user(
+                username=self.DEFAULT_USER_EMAIL,
+                system_name=self.DEFAULT_SYSTEM_NAME,
+                system_token=old_token,
+                password=self.DEFAULT_USER_PASSWORD,
+            )
+            self.assertEqual(login_old.status_code, 401)
+
+            login_new = self.login_user(
+                username=self.DEFAULT_USER_EMAIL,
+                system_name=self.DEFAULT_SYSTEM_NAME,
+                system_token=new_token,
+                password=self.DEFAULT_USER_PASSWORD,
+            )
+            self.assertEqual(login_new.status_code, 200)
+
+    def test_patch_system_token_success_auto_generated(self):
+        """Omitting new_system_token generates a new token server-side."""
+        with self.client:
+            self.create_system(name=self.DEFAULT_SYSTEM_NAME)
+            old_token = self.get_system_token()
+            response = self.patch_system_token(
+                self.DEFAULT_SYSTEM_NAME,
+                current_system_token=old_token,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = json.loads(response.data.decode())
+            self.assertIn('token', data)
+            self.assertNotEqual(data['token'], old_token)
+            self.assertGreater(len(data['token']), 10)
+
+    def test_patch_system_token_system_not_found(self):
+        with self.client:
+            response = self.patch_system_token(
+                'nonexistent',
+                current_system_token='any',
+            )
+            self.assertEqual(response.status_code, 404)
+
+    def test_patch_system_token_wrong_current(self):
+        with self.client:
+            self.create_system(name=self.DEFAULT_SYSTEM_NAME)
+            response = self.patch_system_token(
+                self.DEFAULT_SYSTEM_NAME,
+                current_system_token='wrong-token',
+                new_system_token='new-one',
+            )
+            self.assertEqual(response.status_code, 401)
+            data = json.loads(response.data.decode())
+            self.assertIn('message', data)
+
+    def test_patch_system_token_missing_current(self):
+        with self.client:
+            self.create_system(name=self.DEFAULT_SYSTEM_NAME)
+            response = self.patch_system_token(
+                self.DEFAULT_SYSTEM_NAME,
+                new_system_token='only-new',
+            )
+            self.assertEqual(response.status_code, 400)
+
+    def test_patch_system_token_conflict(self):
+        with self.client:
+            self.create_system(name=self.DEFAULT_SYSTEM_NAME)
+            self.create_system(name='otherSystem')
+            sys_a_token = System.query.filter_by(name=self.DEFAULT_SYSTEM_NAME).first().token
+            sys_b_token = System.query.filter_by(name='otherSystem').first().token
+            response = self.patch_system_token(
+                self.DEFAULT_SYSTEM_NAME,
+                current_system_token=sys_a_token,
+                new_system_token=sys_b_token,
+            )
+            self.assertEqual(response.status_code, 409)
+
+    def test_patch_user_password_success(self):
+        with self.client:
+            resp_register = self.register_default_user()
+            self.assertEqual(resp_register.status_code, 201)
+            access = json.loads(resp_register.data.decode())['auth']['access_token']
+            new_password = 'new-secure-pass-9'
+
+            response = self.patch_user_password(
+                access,
+                current_password=self.DEFAULT_USER_PASSWORD,
+                new_password=new_password,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = json.loads(response.data.decode())
+            self.assertIn('message', data)
+
+            login_old = self.login_default_user()
+            self.assertEqual(login_old.status_code, 401)
+
+            login_new = self.login_user(
+                username=self.DEFAULT_USER_EMAIL,
+                system_name=self.DEFAULT_SYSTEM_NAME,
+                system_token=self.get_system_token(),
+                password=new_password,
+            )
+            self.assertEqual(login_new.status_code, 200)
+
+    def test_patch_user_password_wrong_current(self):
+        with self.client:
+            resp_register = self.register_default_user()
+            access = json.loads(resp_register.data.decode())['auth']['access_token']
+            response = self.patch_user_password(
+                access,
+                current_password='not-the-password',
+                new_password='something-else',
+            )
+            self.assertEqual(response.status_code, 401)
+
+    def test_patch_user_password_empty_new(self):
+        with self.client:
+            resp_register = self.register_default_user()
+            access = json.loads(resp_register.data.decode())['auth']['access_token']
+            response = self.patch_user_password(
+                access,
+                current_password=self.DEFAULT_USER_PASSWORD,
+                new_password='',
+            )
+            self.assertEqual(response.status_code, 400)
+
+    def test_patch_user_password_missing_fields(self):
+        with self.client:
+            resp_register = self.register_default_user()
+            access = json.loads(resp_register.data.decode())['auth']['access_token']
+            response = self.patch_user_password(
+                access,
+                current_password=self.DEFAULT_USER_PASSWORD,
+            )
+            self.assertEqual(response.status_code, 400)
+
+    def test_patch_user_password_no_auth(self):
+        with self.client:
+            response = self.client.patch(
+                '/auth/me/password',
+                data=json.dumps({
+                    'current_password': self.DEFAULT_USER_PASSWORD,
+                    'new_password': 'x',
+                }),
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 401)
+
+    def test_patch_user_password_invalid_token(self):
+        with self.client:
+            response = self.patch_user_password(
+                'invalid.jwt.here',
+                current_password=self.DEFAULT_USER_PASSWORD,
+                new_password='x',
+            )
+            self.assertEqual(response.status_code, 401)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Please use the content below as a template for your pull request.
Feel free to remove sections that do not make sense.
-->

## Scope

What was added and how it behaves.

### 1. `PATCH /auth/systems/<system_name>/token`
- **Auth:** Proves knowledge of the **current** system token (same idea as register/login).
- **Body (JSON):**
  - `current_system_token` (required)
  - `new_system_token` (optional) — if omitted or `""`, a new token is generated with `secrets.token_urlsafe(32)`.
- **Responses:** `200` with `{ "name", "token" }`, `400` missing fields, `401` wrong current token, `404` unknown system, `409` if `new_system_token` is already used by another system.

### 2. `PATCH /auth/me/password`
- **Auth:** `Authorization: Bearer <access_token>` (same as `/auth/me`).
- **Body (JSON):** `current_password`, `new_password` (non-empty).
- **Responses:** `200` with `{ "message": "Password updated." }`, `400` bad/missing body, `401` bad/missing token or wrong current password.

### Code changes
- `User.set_password()` in `project/server/models.py` centralizes bcrypt hashing (aligned with `__init__`).
- `UpdateSystemTokenAPI` and `UpdateUserPasswordAPI` in `project/server/auth/views.py`, plus `secrets` import.
- Tests in `project/tests/test_auth.py` (helpers `patch_system_token` / `patch_user_password` + success/error cases).
- `project/server/docs/static/api.yaml` — two new path stubs with summaries.

**Note:** Changing the password does **not** revoke existing JWTs; only logout/blacklist or expiry does.

All **44** tests passed via `docker exec userver-auth flask test`.

## Checklist :rotating_light:
<!-- Check all items that apply. -->
- [x] My code follows the code style
- [x] Added or updated tests as needed (`flask test`)
- [x] All lints and tests passed correctly locally
- [x] I upgraded dependencies to the latest working version

:heart: Thank you!
