### PR TITLE
docs(env): clarify acme DEFAULT_EMAIL vs per-container LETSENCRYPT_EMAIL

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,6 @@
+# nginx-proxy / acme-companion: set VIRTUAL_HOST to the hostname(s) you serve. LETSENCRYPT_HOST should
+# match when requesting certs. Leave LETSENCRYPT_EMAIL empty if userver-web letsencrypt/.env sets
+# DEFAULT_EMAIL once—repeating the same email on every container breaks ACME (invalidContact).
 VIRTUAL_HOST=
 LETSENCRYPT_HOST=
 LETSENCRYPT_EMAIL=


### PR DESCRIPTION
Document that repeating the same email on many containers breaks ACME when using userver-web nginx-proxy / acme-companion (addresses get concatenated).

<!--
Please use the content below as a template for your pull request.
Feel free to remove sections that do not make sense.
-->

## Scope
<!-- Briefly describe all the changes with bullet points. -->

## Checklist :rotating_light:
<!-- Check all items that apply. -->
- [ ] My code follows the code style
- [ ] Added or updated tests as needed (`flask test`)
- [ ] All lints and tests passed correctly locally
- [ ] I upgraded dependencies to the latest working version

:heart: Thank you!
